### PR TITLE
Platform-independent path join

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -3,7 +3,7 @@ import os, sys
 import dummy
 
 path_curvesWB = os.path.dirname(dummy.__file__)
-sys.path.append(path_curvesWB + '/Gui')
+sys.path.append(os.path.join(path_curvesWB, 'Gui'))
 path_curvesWB_icons =  os.path.join( path_curvesWB, 'Resources', 'icons')
 
 class CurvesWorkbench (Workbench):


### PR DESCRIPTION
[This line](
https://github.com/tomate44/CurvesWB/blob/master/InitGui.py#L6) uses the *nix forward slash path separator. That can cause problems on Windows, and that path shows up as different in the Python console by doing `print(sys.path)` after the workbench loads.

This PR makes sure that path handling is portable in InitGui.py.

Our workbenches (here's [my workbench](https://github.com/jmwright/cadquery-freecad-module)) don't seem to be working well together on FreeCAD 0.17. If your workbench loads first, FreeCAD can't find InitGui.py from my workbench. I suspect there's a path conflict somewhere, but I'm still trying to figure it out.