### PR TITLE
LGTM: fix "Values compared using 'is not' when equivalence is not the.. 

### DIFF
--- a/freecad/Curves/curveExtendFP.py
+++ b/freecad/Curves/curveExtendFP.py
@@ -103,7 +103,7 @@ class extendVP:
 class extendCommand:
     """Extends the selected edge"""
     def makeExtendFeature(self,source):
-        if source is not []:
+        if source != []:
             for o in source:
                 extCurve = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","ExtendedCurve")
                 extend(extCurve)


### PR DESCRIPTION
same as identity. Use `!=` instead."  
https://lgtm.com/projects/g/tomate44/CurvesWB?mode=tree&ruleFocus=7880098