### PR TITLE
Changes to handle curveOnSurface on linked objects.

### DIFF
--- a/freecad/Curves/_utils.py
+++ b/freecad/Curves/_utils.py
@@ -62,31 +62,31 @@ def getShape(obj, prop, shape_type):
         prop_link = obj.getPropertyByName(prop)
         if obj.getTypeIdOfProperty(prop) == "App::PropertyLinkSub":
             if shape_type in prop_link[1][0]:
-                # try:  # FC 0.19+
-                # return prop_link[0].getSubObject(prop_link[1][0])
-                # except AttributeError:  # FC 0.18 (stable)
-                n = eval(obj.getPropertyByName(prop)[1][0].lstrip(shape_type))
-                osh = obj.getPropertyByName(prop)[0].Shape
-                sh = osh.copy()
-                if sh and (not shape_type == "Vertex") and hasattr(obj.getPropertyByName(prop)[0], "getGlobalPlacement"):
-                    pl = obj.getPropertyByName(prop)[0].getGlobalPlacement()
-                    sh.Placement = pl
-                return getSubShape(sh, shape_type, n)
+                try:  # FC 0.19+ to make links work without getGlobalPlacement()
+                    return prop_link[0].getSubObject(prop_link[1][0])
+                except AttributeError:  # FC 0.18 (stable)
+                    n = eval(obj.getPropertyByName(prop)[1][0].lstrip(shape_type))
+                    osh = obj.getPropertyByName(prop)[0].Shape
+                    sh = osh.copy()
+                    if sh and (not shape_type == "Vertex") and hasattr(obj.getPropertyByName(prop)[0], "getGlobalPlacement"):
+                        pl = obj.getPropertyByName(prop)[0].getGlobalPlacement()
+                        sh.Placement = pl
+                    return getSubShape(sh, shape_type, n)
 
         elif obj.getTypeIdOfProperty(prop) == "App::PropertyLinkSubList":
             res = []
             for tup in prop_link:
                 for ss in tup[1]:
                     if shape_type in ss:
-                        # try:  # FC 0.19+
-                        # res.append(tup[0].getSubObject(ss))
-                        # except AttributeError:  # FC 0.18 (stable)
-                        n = eval(ss.lstrip(shape_type))
-                        sh = tup[0].Shape.copy()
-                        if sh and (not shape_type == "Vertex") and hasattr(tup[0], "getGlobalPlacement"):
-                            pl = tup[0].getGlobalPlacement()
-                            sh.Placement = pl
-                        res.append(getSubShape(sh, shape_type, n))
+                        try:  # FC 0.19+
+                            res.append(tup[0].getSubObject(ss))
+                        except AttributeError:  # FC 0.18 (stable)
+                            n = eval(ss.lstrip(shape_type))
+                            sh = tup[0].Shape.copy()
+                            if sh and (not shape_type == "Vertex") and hasattr(tup[0], "getGlobalPlacement"):
+                                pl = tup[0].getGlobalPlacement()
+                                sh.Placement = pl
+                            res.append(getSubShape(sh, shape_type, n))
             return res
         else:
             FreeCAD.Console.PrintError("CurvesWB._utils.getShape: wrong property type.\n")

--- a/freecad/Curves/curveOnSurfaceFP.py
+++ b/freecad/Curves/curveOnSurfaceFP.py
@@ -105,17 +105,17 @@ class cosCommand:
     def Activated(self):
         edge = None
         face = None
-        sel = FreeCADGui.Selection.getSelectionEx()
+        sel = FreeCADGui.Selection.getSelectionEx('',0)
         if sel == []:
             FreeCAD.Console.PrintError("Select an edge and its supporting face \n")
         for selobj in sel:
-            if selobj.HasSubObjects:
-                for i in range(len(selobj.SubObjects)):
-                    if isinstance(selobj.SubObjects[i], Part.Edge):
-                        edge = (selobj.Object, selobj.SubElementNames[i])
-                        #selobj.Object.ViewObject.Visibility = False
-                    elif isinstance(selobj.SubObjects[i], Part.Face):
-                        face = (selobj.Object, selobj.SubElementNames[i])
+            for path in selobj.SubElementNames if selobj.SubElementNames else ['']:
+                shape = selobj.Object.getSubObject(path)
+                if isinstance(shape, Part.Edge):
+                    edge = (selobj.Object, path)
+                elif isinstance(shape, Part.Face):
+                    face = (selobj.Object, path)
+
         #debug(edge)
         #debug(face)
         if edge and face:


### PR DESCRIPTION
Aloha Chris
  This alters the selection process to allow curveonsurface to work on linked objects.  I tested it on the enclosed with

```
tests = [('Box001', ('Face2', 'Edge7')),
    ('Array', ('0.Face2', '0.Edge7')),
    ('Array', ('1.Face2', '1.Edge7')),
    ('Array', ('2.Face2', '2.Edge7')),
    ('Part', ('Box002.Face2', 'Box002.Edge7')),
    ('Link001', ('Box002.Face2', 'Box002.Edge7')),
    ('Link', ('Face2', 'Edge7'))]

Gui.activateWorkbench("CurvesWorkbench")
doc = App.ActiveDocument
for test in tests:
    Gui.Selection.addSelection(doc.getObject(test[0]), test[1], True)
    Gui.runCommand('cos', 0)
```
I didn't test the _elif obj.getTypeIdOfProperty(prop) == "App::PropertyLinkSubList":_  branch.  I'm not sure how those occur.

  I was also trying to fix the BlendSolid tool, in the same manner, but failed to debug it.  

This PR does not contain the one-line change to the BlendSurface tool, mentioned in the forum, 
which passes the tests I tried.

[blendsurftest.FCStd.zip](https://github.com/tomate44/CurvesWB/files/12850949/blendsurftest.FCStd.zip)