### PR TITLE
mute exception when FreeCADGui.ActiveDocument.getInEdit() returns None

### DIFF
--- a/freecad/Curves/gordon_profile_FP.py
+++ b/freecad/Curves/gordon_profile_FP.py
@@ -133,6 +133,8 @@ class GordonProfileFP:
             o = FreeCADGui.ActiveDocument.getInEdit().Object
             if o == obj:
                 return
+        except AttributeError:
+            pass
         except:
             FreeCAD.Console.PrintWarning("execute is disabled during editing\n")
         pts = self.get_points(obj)


### PR DESCRIPTION
Fixes #85, however whole part with exception looks strange and probably is either obsolete, or needs refactoring.