### PR TITLE
add SurfaceOfRevolution to build_sketch calculation

### DIFF
--- a/freecad/Curves/Sketch_On_Surface.py
+++ b/freecad/Curves/Sketch_On_Surface.py
@@ -445,7 +445,13 @@ def build_sketch(sk, fa):
     elif isinstance(fa.Surface, Part.OffsetSurface) and isinstance(fa.Surface.BasisSurface, Part.SurfaceOfExtrusion) and isinstance(fa.Surface.BasisSurface.BasisCurve, Part.BSplineCurve):
         u0 = 0
         u1 = fa.Surface.BasisSurface.BasisCurve.length()
-
+    elif isinstance(fa.Surface, Part.SurfaceOfRevolution) and isinstance(fa.Surface.BasisCurve, Part.BSplineCurve):
+        u1 = fa.Surface.BasisCurve.length()
+        v1 = fa.Area / u1
+    elif isinstance(fa.Surface, Part.OffsetSurface) and isinstance(fa.Surface.BasisSurface, Part.SurfaceOfRevolution) and isinstance(fa.Surface.BasisCurve.BasisCurve, Part.BSplineCurve):
+        u1 = fa.Surface.BasisSurface.BasisCurve.length()
+        v1 = fa.Area / u1
+    
     addFaceBoundsToSketch([u0, u1, v0, v1], sk)
     # elif isinstance(fa.Surface, Part.Cone):
         # u1 = 0.5 * (fa.Edge1.Length + fa.Edge3.Length)


### PR DESCRIPTION
Possibly fixes #82, tested just on simple revoluted surface

Before (generally just using fa.ParameterRange, so resulting sketch is really tiny):
![fcad_surface_of_revolution_pre](https://github.com/tomate44/CurvesWB/assets/29592098/a8650beb-265a-488d-a154-dcae30958710)

After:
![fcad_surface_of_revolution_post](https://github.com/tomate44/CurvesWB/assets/29592098/ad9c3b3c-9cc1-4be0-bdf4-c57259f72e29)

Using area as a base for calculating second dimension may not be the best approach, but works ok for variety of curves.