### PR TITLE
Fix issue #97 Object of type FeaturePython is not JSON serializable

### DIFF
--- a/freecad/Curves/Discretize.py
+++ b/freecad/Curves/Discretize.py
@@ -228,12 +228,21 @@ class ViewProviderDisc:
     def attach(self, vobj):
         self.Object = vobj.Object
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self, state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
     def claimChildren(self):
         return [self.Object.Edge[0]]

--- a/freecad/Curves/DraftAnalysisFP.py
+++ b/freecad/Curves/DraftAnalysisFP.py
@@ -100,12 +100,21 @@ class DraftAnalysisProxyVP:
         self.draft_analyzer = DraftAnalysisShader()
         self.load_shader(viewobj)
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self, state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
     def updateData(self, fp, prop):
         if prop == "Source":

--- a/freecad/Curves/FaceMapFP.py
+++ b/freecad/Curves/FaceMapFP.py
@@ -108,12 +108,21 @@ class FaceMapVP:
     def attach(self, viewobj):
         self.Object = viewobj.Object
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self, state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
 
 class ToolCommand:

--- a/freecad/Curves/HQRuledSurfaceFP.py
+++ b/freecad/Curves/HQRuledSurfaceFP.py
@@ -135,12 +135,21 @@ class HQ_Ruled_SurfaceVP:
     def attach(self, vobj):
         self.Object = vobj.Object
 
-    def __getstate__(self):
-        return({"name": self.Object.Name})
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self,state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return(None)
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
 class HQ_Ruled_Surface_Command:
     """Creates a ..."""

--- a/freecad/Curves/HelicalSweepFP.py
+++ b/freecad/Curves/HelicalSweepFP.py
@@ -232,12 +232,21 @@ class HelicalSweepVP:
     def claimChildren(self):
         return [self.Object.Profile]
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self,state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
 class HelicalSweepCommand:
     """Creates a HelicalSweep Object"""

--- a/freecad/Curves/IsoCurve.py
+++ b/freecad/Curves/IsoCurve.py
@@ -181,12 +181,21 @@ class ViewProviderIsoCurve:
     def attach(self, vobj):
         self.Object = vobj.Object
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (App.Version()[0]+'.'+App.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self,state):
-        self.Object = App.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = App.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = App.ActiveDocument.getObject(state["name"])
+            return None
 
 class CommandMacroIsoCurve:
     "Command to create IsoCurve feature"

--- a/freecad/Curves/JoinCurves.py
+++ b/freecad/Curves/JoinCurves.py
@@ -182,12 +182,21 @@ class joinVP:
     def attach(self, vobj):
         self.Object = vobj.Object
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self, state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
     # def claimChildren(self):
         # return None #[self.Object.Base, self.Object.Tool]

--- a/freecad/Curves/Outline_FP.py
+++ b/freecad/Curves/Outline_FP.py
@@ -122,12 +122,21 @@ class OutlineVP:
     def attach(self, vobj):
         self.Object = vobj.Object
 
-    def __getstate__(self):
-        return({"name": self.Object.Name})
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self,state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return(None)
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
 class outline_cmd:
     """Creates a Outline curve"""

--- a/freecad/Curves/ParametricBlendCurve.py
+++ b/freecad/Curves/ParametricBlendCurve.py
@@ -489,12 +489,21 @@ class BlendCurveVP:
             FreeCAD.ActiveDocument.recompute()
         return True
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self, state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
     def getChildren(self):
         return [self.Object.Edge1[0], self.Object.Edge2[0]]
@@ -600,14 +609,25 @@ class oldBlendCurveVP:
         # return(_utils.iconsPath() + '/blend2.svg')
         return TOOL_ICON
 
-    def __getstate__(self):
-        return({"name": self.Object.Name})
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self, state):
-        debug("setstate")
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        self.build()
-        return None
+        def loads(self, state):
+          debug("setstate")
+          self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+          self.build()
+          return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+          debug("setstate")
+          self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+          self.build()
+          return None
 
     def onDelete(self, feature, subelements):
         if hasattr(self, 'active'):

--- a/freecad/Curves/ParametricComb.py
+++ b/freecad/Curves/ParametricComb.py
@@ -376,12 +376,21 @@ class Comb:
             debug("Comb : Samples Property changed")
             self.execute(fp)
 
-    def __getstate__(self):
-        self.edges = False
-        return dict()
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+          self.edges = False
+          return dict()
 
-    def __setstate__(self, state):
-        return None
+        def loads(self, state):
+            return None
+
+    else:
+        def __getstate__(self):
+          self.edges = False
+          return dict()
+
+        def __setstate__(self, state):
+            return None
 
 class ViewProviderComb:
     def __init__(self, obj):
@@ -509,12 +518,21 @@ class ViewProviderComb:
     def getIcon(self):
         return TOOL_ICON
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self, state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
 
 class ParametricComb:

--- a/freecad/Curves/PlateSurface.py
+++ b/freecad/Curves/PlateSurface.py
@@ -132,11 +132,19 @@ class plateSurfFP:
             if fp.Tol3d > 0.002:
                 fp.Tol3d = 0.002
 
-    def __getstate__(self):
-        return None
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return None
 
-    def __setstate__(self,state):
-        return None
+        def loads(self, state):
+            return None
+
+    else:
+        def __getstate__(self):
+            return None
+
+        def __setstate__(self, state):
+            return None
 
 
 class Plate:

--- a/freecad/Curves/ProfileSketch.py
+++ b/freecad/Curves/ProfileSketch.py
@@ -85,11 +85,19 @@ class profileSupportVP:
         self.ViewObject = vobj
         self.Object = vobj.Object
 
-    def __getstate__(self):
-        return None
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return None
 
-    def __setstate__(self, state):
-        return None
+        def loads(self, state):
+            return None
+
+    else:
+        def __getstate__(self):
+            return None
+
+        def __setstate__(self, state):
+            return None
 
     # def claimChildren(self):
         # return None #[self.Object.Base, self.Object.Tool]

--- a/freecad/Curves/ProfileSupportFP.py
+++ b/freecad/Curves/ProfileSupportFP.py
@@ -173,15 +173,24 @@ class ProfileSupportVP:
     def attach(self, viewobj):
         self.Object = viewobj.Object
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
-
     def claimChildren(self):
         return [self.Object.ProfileShape, ]
 
-    def __setstate__(self, state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
+
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
 
 class ProfileSupportCommand:

--- a/freecad/Curves/ReflectLinesFP.py
+++ b/freecad/Curves/ReflectLinesFP.py
@@ -142,12 +142,21 @@ class ReflectLinesVP:
     def cameramove(self, *args):
         self.Object.ViewDir = FreeCADGui.ActiveDocument.ActiveView.getCameraOrientation().multVec(FreeCAD.Vector(0,0,1))
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self, state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
 
 class ReflectLinesCommand:

--- a/freecad/Curves/RotationSweepFP.py
+++ b/freecad/Curves/RotationSweepFP.py
@@ -121,12 +121,21 @@ class RotsweepProxyVP:
     def attach(self, viewobj):
         self.Object = viewobj.Object
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self, state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
 
 class RotsweepFPCommand:

--- a/freecad/Curves/Sketch_On_Surface.py
+++ b/freecad/Curves/Sketch_On_Surface.py
@@ -380,12 +380,21 @@ class sosVP:
     def attach(self, vobj):
         self.Object = vobj.Object
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self, state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
     def claimChildren(self):
         return [self.Object.Sketch]

--- a/freecad/Curves/SurfaceAnalysisFP.py
+++ b/freecad/Curves/SurfaceAnalysisFP.py
@@ -135,12 +135,21 @@ class SurfaceAnalysisProxyVP:
         self.surf_analyze = SurfaceAnalysisShader(0, 0)
         self.load_shader()
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self, state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
     def updateData(self, fp, prop):
         if prop == "Sources":

--- a/freecad/Curves/Sweep2Rails.py
+++ b/freecad/Curves/Sweep2Rails.py
@@ -159,11 +159,19 @@ class sweep2railsVP:
     def unsetEdit(self, vobj, mode):
         return
 
-    def __getstate__(self):
-        return None
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return None
 
-    def __setstate__(self, state):
-        return None
+        def loads(self, state):
+            return None
+
+    else:
+        def __getstate__(self):
+            return None
+
+        def __setstate__(self, state):
+            return None
 
     def claimChildren(self):
         a = self.Object.Profiles

--- a/freecad/Curves/Sweep2RailsFP.py
+++ b/freecad/Curves/Sweep2RailsFP.py
@@ -119,12 +119,21 @@ class Sweep2RailsViewProxy:
     def attach(self, viewobj):
         self.Object = viewobj.Object
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self, state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
 
 class Sweep2RailsCommand:

--- a/freecad/Curves/TemplateFP.py
+++ b/freecad/Curves/TemplateFP.py
@@ -93,12 +93,21 @@ class FaceMapVP:
     def attach(self, viewobj):
         self.Object = viewobj.Object
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self, state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
 
 class ToolCommand:

--- a/freecad/Curves/TrimFace.py
+++ b/freecad/Curves/TrimFace.py
@@ -151,12 +151,21 @@ class trimFaceVP:
                 children.append(self.Object.Tool[0])
         return children
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self, state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
 
 class trim:

--- a/freecad/Curves/approximate.py
+++ b/freecad/Curves/approximate.py
@@ -310,12 +310,21 @@ class Approximate:
             else:
                 fp.setEditorMode("StartOffset", 2)
 
-    def __getstate__(self):
-        self.Points = False
-        return dict()
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            self.Points = False
+            return dict()
 
-    def __setstate__(self, state):
-        return None
+        def loads(self, state):
+            return None
+
+    else:
+        def __getstate__(self):
+            self.Points = False
+            return dict()
+
+        def __setstate__(self, state):
+            return None
 
 
 class ViewProviderApp:
@@ -334,12 +343,21 @@ class ViewProviderApp:
     def unsetEdit(self, vobj, mode):
         return
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self, state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
     def claimChildren(self):
         return [self.Object.PointObject]

--- a/freecad/Curves/blendSolidFP.py
+++ b/freecad/Curves/blendSolidFP.py
@@ -165,12 +165,21 @@ class BlendSolidViewProxy:
     def attach(self, viewobj):
         self.Object = viewobj.Object
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self, state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
     def claimChildren(self):
         if self.Object.ShapeType == "Fused":

--- a/freecad/Curves/blendSurfaceFP.py
+++ b/freecad/Curves/blendSurfaceFP.py
@@ -264,6 +264,20 @@ class blendSurfVP:
     def __setstate__(self,state):
         return None
 
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return None
+
+        def loads(self, state):
+            return None
+
+    else:
+        def __getstate__(self):
+            return None
+
+        def __setstate__(self, state):
+            return None
+
     def claimChildren(self):
         a = [self.Object.Edge1, self.Object.Edge2]
         return a

--- a/freecad/Curves/blendSurfaceFP_new.py
+++ b/freecad/Curves/blendSurfaceFP_new.py
@@ -103,12 +103,21 @@ class BlendSurfaceVP2:
     def attach(self, viewobj):
         self.Object = viewobj.Object
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self, state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
 
 class BlendSurf2Command:

--- a/freecad/Curves/comp_spring.py
+++ b/freecad/Curves/comp_spring.py
@@ -144,12 +144,21 @@ class CompSpringVP:
     def attach(self, vobj):
         self.Object = vobj.Object
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self, state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
 
 class CompSpringCommand:

--- a/freecad/Curves/continuity_check.py
+++ b/freecad/Curves/continuity_check.py
@@ -158,12 +158,21 @@ class ContinuityCheckerVP:
     def attach(self, viewobj):
         self.Object = viewobj.Object
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self, state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
 
 class ContinuityCheckerCommand:

--- a/freecad/Curves/curveExtendFP.py
+++ b/freecad/Curves/curveExtendFP.py
@@ -96,12 +96,21 @@ class extendVP:
     def onDelete(self, feature, subelements):
         return True
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self, state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
 
 class extendCommand:

--- a/freecad/Curves/curveOnSurfaceFP.py
+++ b/freecad/Curves/curveOnSurfaceFP.py
@@ -81,12 +81,21 @@ class cosVP:
     def attach(self, vobj):
         self.Object = vobj.Object
 
-    def __getstate__(self):
-        return({"name": self.Object.Name})
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self,state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return(None)
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
     def claimChildren(self):
         return [self.Object.InputEdge[0]]

--- a/freecad/Curves/gordonFP.py
+++ b/freecad/Curves/gordonFP.py
@@ -176,12 +176,21 @@ class gordonVP:
         else:
             return []
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self, state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
 
 class gordonCommand:

--- a/freecad/Curves/gordon_profile_FP.py
+++ b/freecad/Curves/gordon_profile_FP.py
@@ -284,12 +284,21 @@ class GordonProfileVP:
             self.active = False
         return True
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self, state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
 
 class GordonProfileCommand:

--- a/freecad/Curves/interpolate.py
+++ b/freecad/Curves/interpolate.py
@@ -297,12 +297,21 @@ class ViewProviderInterpolate:
     def unsetEdit(self, vobj, mode):
         return
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self, state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
     # def claimChildren(self):
         # return [self.Object.PointObject]

--- a/freecad/Curves/lineFP.py
+++ b/freecad/Curves/lineFP.py
@@ -44,12 +44,21 @@ class lineVP:
     def attach(self, vobj):
         self.Object = vobj.Object
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self, state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
 
 class lineCommand:

--- a/freecad/Curves/mixed_curve.py
+++ b/freecad/Curves/mixed_curve.py
@@ -122,12 +122,21 @@ class MixedCurveVP:
     def attach(self, vobj):
         self.Object = vobj.Object
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self, state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
     def claimChildren(self):
         return [self.Object.Shape1, self.Object.Shape2]

--- a/freecad/Curves/multiLoftFP.py
+++ b/freecad/Curves/multiLoftFP.py
@@ -72,12 +72,21 @@ class MultiLoftVP:
     def attach(self, vobj):
         self.Object = vobj.Object
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self, state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
     def claimChildren(self):
         return self.Object.Sources

--- a/freecad/Curves/parametricSolid.py
+++ b/freecad/Curves/parametricSolid.py
@@ -118,12 +118,21 @@ class solidVP:
         if prop == "ShapeStatus":
             fp.ViewObject.signalChangeIcon()
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self, state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
 
 class solidCommand:

--- a/freecad/Curves/pipeshellFP.py
+++ b/freecad/Curves/pipeshellFP.py
@@ -318,11 +318,19 @@ class pipeShellVP:
     def unsetEdit(self, vobj, mode):
         return
 
-    def __getstate__(self):
-        return None
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return None
 
-    def __setstate__(self, state):
-        return None
+        def loads(self, state):
+            return None
+
+    else:
+        def __getstate__(self):
+            return None
+
+        def __setstate__(self, state):
+            return None
 
     def claimChildren(self):
         return (self.Object.Profiles + [self.Object.Spine])

--- a/freecad/Curves/pipeshellProfileFP.py
+++ b/freecad/Curves/pipeshellProfileFP.py
@@ -102,11 +102,19 @@ class profileVP:
     def unsetEdit(self,vobj,mode):
         return
 
-    def __getstate__(self):
-        return None
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return None
 
-    def __setstate__(self,state):
-        return None
+        def loads(self, state):
+            return None
+
+    else:
+        def __getstate__(self):
+            return None
+
+        def __setstate__(self, state):
+            return None
 
     #def claimChildren(self):
         #return None #[self.Object.Edge[0]]

--- a/freecad/Curves/segmentSurfaceFP.py
+++ b/freecad/Curves/segmentSurfaceFP.py
@@ -163,12 +163,21 @@ class SegmentSurfaceVP:
                 return [self.Object.Source[0]]
         return []
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self, state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
 
 class SegSurfCommand:

--- a/freecad/Curves/splitCurves_2.py
+++ b/freecad/Curves/splitCurves_2.py
@@ -553,12 +553,21 @@ class splitVP:
             self.active = False
         return True
 
-    def __getstate__(self):
-        return {"name": self.Object.Name}
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            return {"name": self.Object.Name}
 
-    def __setstate__(self, state):
-        self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
-        return None
+        def loads(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
+
+    else:
+        def __getstate__(self):
+            return {"name": self.Object.Name}
+
+        def __setstate__(self, state):
+            self.Object = FreeCAD.ActiveDocument.getObject(state["name"])
+            return None
 
     def claimChildren(self):
         if self.Object.Source:


### PR DESCRIPTION
Since Py3.11 the methods names setstate and getstate conflict with the method names added to the object class.
In the FreeCAD dev (0.22 and more) the methods named __setstate__ and __getstate__ have been renamed to 'loads' and 'dumps'. This have been published in the [FreeCAD App: Fixe #10460](https://github.com/FreeCAD/FreeCAD/commit/83d4080fe8)

This patch add a test of FreeCAD version, and if it's >0.22, expose the 'loads' and 'dumps' methods, if the version is less than 0.22, the \_\_setstate\_\_ and \_\_getstate\_\_ methods are exposed.

This path have been tested on Linux (Debian 12.2 / FreeCAD dev 0.22) and Windows 10, FreeCAD 0.20 & 0.21

@++;
Gauthier.
