### PR TITLE
fixes #153 Curves command not found after right click on tree view

### DIFF
--- a/freecad/Curves/init_gui.py
+++ b/freecad/Curves/init_gui.py
@@ -140,7 +140,7 @@ class CurvesWorkbench(Gui.Workbench):
             contextlist = ["Curves_adjacent_faces", "Curves_bspline_to_console"]  # list of commands
             self.appendContextMenu("Curves", contextlist)
         elif recipient == "Tree":
-            contextlist = []  # list of commands
+            contextlist = ["join", "split", "Discretize", "Approximate", "Interpolate"]  # list of commands
             self.appendContextMenu("Curves", contextlist)
 
     def GetClassName(self):


### PR DESCRIPTION
Fixes unpopulated list of command in a tree view menu. Not sure if it's really useful there, but why not. 

![image](https://github.com/user-attachments/assets/0701d7f7-32da-49fe-af94-cfcc50c71f37)
