### PR TITLE
[ Add ] SPDX License Identifiers

### DIFF
--- a/freecad/Curves/Blending/smooth_objects.py
+++ b/freecad/Curves/Blending/smooth_objects.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = ""
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/CoinNodes.py
+++ b/freecad/Curves/CoinNodes.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import FreeCAD
 import FreeCADGui
 import Part

--- a/freecad/Curves/Discretize.py
+++ b/freecad/Curves/Discretize.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Discretize"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/DraftAnalysisFP.py
+++ b/freecad/Curves/DraftAnalysisFP.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = 'Draft Analysis'
 __author__ = 'Christophe Grellier (Chris_G)'

--- a/freecad/Curves/DraftAnalysis_shaders/DraftAnalysis_shader.py
+++ b/freecad/Curves/DraftAnalysis_shaders/DraftAnalysis_shader.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 from pivy import coin
 from os import path
 

--- a/freecad/Curves/ExtractShapes.py
+++ b/freecad/Curves/ExtractShapes.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Extract subshape"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/FC_interaction_example.py
+++ b/freecad/Curves/FC_interaction_example.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import FreeCAD
 import FreeCADGui
 import Part

--- a/freecad/Curves/FaceMapFP.py
+++ b/freecad/Curves/FaceMapFP.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Face Map"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/FlattenFP.py
+++ b/freecad/Curves/FlattenFP.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = 'Flatten face'
 __author__ = 'Christophe Grellier (Chris_G)'

--- a/freecad/Curves/GeomInfo.py
+++ b/freecad/Curves/GeomInfo.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "GeomInfo"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/Gui/Zebra_Gui.py
+++ b/freecad/Curves/Gui/Zebra_Gui.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 # Form implementation generated from reading ui file './Zebra_Gui.ui'
 #

--- a/freecad/Curves/Gui/__init__.py
+++ b/freecad/Curves/Gui/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later

--- a/freecad/Curves/HQRuledSurfaceFP.py
+++ b/freecad/Curves/HQRuledSurfaceFP.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "HQ Ruled surface"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/HUD.py
+++ b/freecad/Curves/HUD.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import FreeCAD
 import FreeCADGui
 from pivy import coin

--- a/freecad/Curves/HelicalSweepFP.py
+++ b/freecad/Curves/HelicalSweepFP.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Helical Sweep"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/IsoCurve.py
+++ b/freecad/Curves/IsoCurve.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 __title__ = "Macro IsoCurves"
 __author__ = "Chris_G"
 __doc__ = '''

--- a/freecad/Curves/JoinCurves.py
+++ b/freecad/Curves/JoinCurves.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "joinCurves"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/MapOnFaceFP.py
+++ b/freecad/Curves/MapOnFaceFP.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = 'MapOnFace'
 __author__ = 'Christophe Grellier (Chris_G)'

--- a/freecad/Curves/Outline_FP.py
+++ b/freecad/Curves/Outline_FP.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Outline Curve"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/ParametricBlendCurve.py
+++ b/freecad/Curves/ParametricBlendCurve.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Blend curve"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/ParametricComb.py
+++ b/freecad/Curves/ParametricComb.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Comb plot"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/PlateSurface.py
+++ b/freecad/Curves/PlateSurface.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 from __future__ import division # allows floating point division from integers
 import FreeCAD, Part, math
 import os, dummy, FreeCADGui

--- a/freecad/Curves/PointInterpolate.py
+++ b/freecad/Curves/PointInterpolate.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import Part
 import numpy as np
 from freecad.Curves import PointParameters

--- a/freecad/Curves/PointInterpolation.py
+++ b/freecad/Curves/PointInterpolation.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import FreeCAD
 import FreeCADGui
 import Part

--- a/freecad/Curves/PointParameters.py
+++ b/freecad/Curves/PointParameters.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import Part
 
 

--- a/freecad/Curves/ProfileSketch.py
+++ b/freecad/Curves/ProfileSketch.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = 'Profile support plane'
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/ProfileSupportFP.py
+++ b/freecad/Curves/ProfileSupportFP.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = 'Profile Support'
 __author__ = 'Christophe Grellier (Chris_G)'

--- a/freecad/Curves/ReflectLinesFP.py
+++ b/freecad/Curves/ReflectLinesFP.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Reflect Lines"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/RotationSweepFP.py
+++ b/freecad/Curves/RotationSweepFP.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = 'Rotation Sweep'
 __author__ = 'Christophe Grellier (Chris_G)'

--- a/freecad/Curves/ShapeMapper.py
+++ b/freecad/Curves/ShapeMapper.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import FreeCAD
 import FreeCADGui
 import Part

--- a/freecad/Curves/Sketch_On_Surface.py
+++ b/freecad/Curves/Sketch_On_Surface.py
@@ -1,4 +1,4 @@
-#  -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Sketch on surface"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/SurfaceAnalysisFP.py
+++ b/freecad/Curves/SurfaceAnalysisFP.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = 'Title'
 __author__ = 'Christophe Grellier (Chris_G)'

--- a/freecad/Curves/Sweep2Rails.py
+++ b/freecad/Curves/Sweep2Rails.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import os
 import FreeCAD
 import FreeCADGui

--- a/freecad/Curves/Sweep2RailsFP.py
+++ b/freecad/Curves/Sweep2RailsFP.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = 'Sweep 2 Rails'
 __author__ = 'Christophe Grellier (Chris_G)'

--- a/freecad/Curves/SweepObject.py
+++ b/freecad/Curves/SweepObject.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import FreeCAD
 import Part
 vec2 = FreeCAD.Base.Vector2d

--- a/freecad/Curves/SweepObject_2.py
+++ b/freecad/Curves/SweepObject_2.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import FreeCAD
 import Part
 vec2 = FreeCAD.Base.Vector2d

--- a/freecad/Curves/SweepPath.py
+++ b/freecad/Curves/SweepPath.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import FreeCAD
 import Part
 from freecad.Curves import curves_to_surface as CTS

--- a/freecad/Curves/TemplateFP.py
+++ b/freecad/Curves/TemplateFP.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = 'Title'
 __author__ = 'Christophe Grellier (Chris_G)'

--- a/freecad/Curves/TrimFace.py
+++ b/freecad/Curves/TrimFace.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = 'Trim face'
 __author__ = 'Christophe Grellier (Chris_G)'

--- a/freecad/Curves/Truncate_Extend.py
+++ b/freecad/Curves/Truncate_Extend.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 class TruncateExtend:
     """Truncate or extend a shape by a given distance
     te = TruncateExtend(shape, cutter, distance, reverse=False)

--- a/freecad/Curves/Truncate_Extend_FP.py
+++ b/freecad/Curves/Truncate_Extend_FP.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = 'Truncate Extend'
 __author__ = 'Christophe Grellier (Chris_G)'

--- a/freecad/Curves/WaterLineFP.py
+++ b/freecad/Curves/WaterLineFP.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = 'WaterLine'
 __author__ = 'Christophe Grellier (Chris_G)'

--- a/freecad/Curves/Waterline_shaders/Waterline_shader.py
+++ b/freecad/Curves/Waterline_shaders/Waterline_shader.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import FreeCAD as App
 import FreeCADGui as Gui
 from pivy import coin

--- a/freecad/Curves/ZebraTool.py
+++ b/freecad/Curves/ZebraTool.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import os
 import FreeCAD
 import FreeCADGui

--- a/freecad/Curves/Zebra_shaders/Zebra_shader.py
+++ b/freecad/Curves/Zebra_shaders/Zebra_shader.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import FreeCAD as App
 import FreeCADGui as Gui
 from pivy import coin

--- a/freecad/Curves/__init__.py
+++ b/freecad/Curves/__init__.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import os
 import FreeCAD
 from .version import __version__

--- a/freecad/Curves/_utils.py
+++ b/freecad/Curves/_utils.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Curves workbench utilities"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/adjacent_faces.py
+++ b/freecad/Curves/adjacent_faces.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Select Adjacent faces"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/approximate.py
+++ b/freecad/Curves/approximate.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Approximate"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/approximate_extension.py
+++ b/freecad/Curves/approximate_extension.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Approximate extension"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/blendSolidFP.py
+++ b/freecad/Curves/blendSolidFP.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "BlendSolid"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/blendSolids.py
+++ b/freecad/Curves/blendSolids.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import FreeCAD
 import FreeCADGui
 import Part

--- a/freecad/Curves/blendSurface.py
+++ b/freecad/Curves/blendSurface.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import FreeCAD
 import Part
 from freecad.Curves.curveOnSurface import curveOnSurface

--- a/freecad/Curves/blendSurfaceFP.py
+++ b/freecad/Curves/blendSurfaceFP.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import os
 import FreeCAD
 import FreeCADGui

--- a/freecad/Curves/blendSurfaceFP_new.py
+++ b/freecad/Curves/blendSurfaceFP_new.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "BlendSurface"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/blend_curve.py
+++ b/freecad/Curves/blend_curve.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = ""
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/comp_spring.py
+++ b/freecad/Curves/comp_spring.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Compression Spring"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/continuity_check.py
+++ b/freecad/Curves/continuity_check.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = 'Title'
 __author__ = 'Christophe Grellier (Chris_G)'

--- a/freecad/Curves/curveExtend.py
+++ b/freecad/Curves/curveExtend.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import math
 import FreeCAD
 import Part

--- a/freecad/Curves/curveExtendFP.py
+++ b/freecad/Curves/curveExtendFP.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Curve extend"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/curveOnSurface.py
+++ b/freecad/Curves/curveOnSurface.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import FreeCAD
 import Part
 from Part import Geom2d

--- a/freecad/Curves/curveOnSurfaceFP.py
+++ b/freecad/Curves/curveOnSurfaceFP.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Curve on surface"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/curve_network_sorter.py
+++ b/freecad/Curves/curve_network_sorter.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 # This file is a python port of /src/guide_curves/CTiglCurveNetworkSorter.cpp
 # from the Tigl library : https://github.com/DLR-SC/tigl under Apache-2 license
 import FreeCAD

--- a/freecad/Curves/curve_to_script.py
+++ b/freecad/Curves/curve_to_script.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "BSpline to script"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/curves_to_surface.py
+++ b/freecad/Curves/curves_to_surface.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Curves to Surface"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/fix_wire.py
+++ b/freecad/Curves/fix_wire.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 from math import pi
 import Part
 from . import TOL3D

--- a/freecad/Curves/fuzzy_wire.py
+++ b/freecad/Curves/fuzzy_wire.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import FreeCAD
 import FreeCADGui as Gui
 import Part

--- a/freecad/Curves/gordonFP.py
+++ b/freecad/Curves/gordonFP.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Parametric Gordon surface"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/gordon_profile_FP.py
+++ b/freecad/Curves/gordon_profile_FP.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Freehand BSpline"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/graphics.py
+++ b/freecad/Curves/graphics.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 from pivy import coin
 #from pivy.utils import getPointOnScreen
 

--- a/freecad/Curves/grid.py
+++ b/freecad/Curves/grid.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import FreeCAD
 import FreeCADGui
 import math

--- a/freecad/Curves/grid2.py
+++ b/freecad/Curves/grid2.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 from math import pi
 from pivy import coin
 import Part

--- a/freecad/Curves/helix_on_face.py
+++ b/freecad/Curves/helix_on_face.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 def helix_on_face(face, turns=1.0, wire_output=True):
     """
     Create an helix shape on a periodic face.

--- a/freecad/Curves/import3DM.py
+++ b/freecad/Curves/import3DM.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 __title__ = "import3DM"
 __author__ = "Christophe Grellier (Chris_G) - Keith Sloan (keithsloan52)"
 __license__ = "LGPL 2.1"

--- a/freecad/Curves/init_gui.py
+++ b/freecad/Curves/init_gui.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import os
 import FreeCADGui as Gui
 import FreeCAD as App

--- a/freecad/Curves/interpolate.py
+++ b/freecad/Curves/interpolate.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Interpolate"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/isocurves.py
+++ b/freecad/Curves/isocurves.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 __title__ = "isoCurves for FreeCAD"
 __author__ = "Chris_G"
 __license__ = "LGPL 2.1"

--- a/freecad/Curves/libS2R.py
+++ b/freecad/Curves/libS2R.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import os
 import math
 import FreeCAD

--- a/freecad/Curves/lineFP.py
+++ b/freecad/Curves/lineFP.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Parametric line"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/manipulators.py
+++ b/freecad/Curves/manipulators.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Manipulators"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/map_on_face.py
+++ b/freecad/Curves/map_on_face.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import FreeCAD
 import FreeCADGui
 import Part

--- a/freecad/Curves/match_wires.py
+++ b/freecad/Curves/match_wires.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import FreeCADGui
 import Part
 from numpy import arange

--- a/freecad/Curves/mixed_curve.py
+++ b/freecad/Curves/mixed_curve.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Mixed curve"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/multiLoftFP.py
+++ b/freecad/Curves/multiLoftFP.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "MultiLoft"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/nurbs_surface_match.py
+++ b/freecad/Curves/nurbs_surface_match.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import FreeCAD
 import Part
 

--- a/freecad/Curves/nurbs_tools.py
+++ b/freecad/Curves/nurbs_tools.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Nurbs tools"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/parametricSolid.py
+++ b/freecad/Curves/parametricSolid.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Parametric solid"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/pasteSVG.py
+++ b/freecad/Curves/pasteSVG.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Paste SVG"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/pipeshellFP.py
+++ b/freecad/Curves/pipeshellFP.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = 'Pipeshell'
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/pipeshellProfileFP.py
+++ b/freecad/Curves/pipeshellProfileFP.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = 'Pipeshell profile'
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/profile_editor.py
+++ b/freecad/Curves/profile_editor.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import FreeCAD
 import FreeCADGui
 import Part

--- a/freecad/Curves/property_editor.py
+++ b/freecad/Curves/property_editor.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import FreeCAD
 import FreeCADGui
 import Part

--- a/freecad/Curves/reparametrize.py
+++ b/freecad/Curves/reparametrize.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Curve re-parametrize"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/ribbon.py
+++ b/freecad/Curves/ribbon.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import FreeCAD
 import FreeCADGui
 import Part

--- a/freecad/Curves/segmentSurfaceFP.py
+++ b/freecad/Curves/segmentSurfaceFP.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Segment surface"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/selFilter.py
+++ b/freecad/Curves/selFilter.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 import FreeCADGui
 
 class selFilter:

--- a/freecad/Curves/splitCurves_2.py
+++ b/freecad/Curves/splitCurves_2.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Split curve"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/sublink_edit.py
+++ b/freecad/Curves/sublink_edit.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = "Sublink Editor"
 __author__ = "Christophe Grellier (Chris_G)"

--- a/freecad/Curves/toConsole.py
+++ b/freecad/Curves/toConsole.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 __title__ = 'Objects to Console'
 __author__ = 'Christophe Grellier (Chris_G)'

--- a/freecad/Curves/version.py
+++ b/freecad/Curves/version.py
@@ -1,1 +1,3 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 __version__ = "0.4"

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 from setuptools import setup
 import os
 from freecad.Curves.version import __version__


### PR DESCRIPTION
- Added SPDX License identifiers to remaining unmarked files
- At the same time removed Python 2 utf-8 annotations
( FreeCAD only uses Python 3, no need for them anymore ) 