### PR TITLE
Fixup for parsing attachment support face names like '?Face1'

### DIFF
--- a/freecad/Curves/Sketch_On_Surface.py
+++ b/freecad/Curves/Sketch_On_Surface.py
@@ -16,6 +16,7 @@ from freecad.Curves import ICONPATH
 TOOL_ICON = os.path.join(ICONPATH, 'sketch_surf.svg')
 
 debug = _utils.debug
+warn = _utils.warn
 # debug = _utils.doNothing
 vec = FreeCAD.Vector
 error = FreeCAD.Console.PrintError
@@ -305,7 +306,11 @@ class sketchOnSurface:
                 supp = obj.Sketch.Support
             if hasattr(obj.Sketch, "AttachmentSupport"):
                 supp = obj.Sketch.AttachmentSupport
-            n = eval(supp[0][1][0].lstrip('Face'))
+            n = supp[0][1][0].lstrip('Face')
+            if not n.isnumeric():
+                warn("Possible topological naming issue with supporting face {}\n".format(supp[0][1][0]))
+                n = supp[0][1][0].lstrip('?Face')
+            n = int(n)
             face = supp[0][0].Shape.Faces[n - 1]
             # face.Placement = obj.Sketch.Support[0][0].getGlobalPlacement()
         except (IndexError, AttributeError, SyntaxError) as e:


### PR DESCRIPTION
I use a lot of parametric bodies, curves, etc in my designs (via spreadsheets,additional attributes, etc), and batch mode of FreeCAD to generate many STL files (mostly aimed at 3D printing) with different sizes/features/etc from one Part model.
So some false positive topo naming problems are unavoidable during altering parameters.
And here is this small fix.

BTW: thanks for great CurvesWB plugin - it helps me a lot!
