### PR TITLE
Sketch_On_Surface: fix hang on empty sketch and crash on out-of-bounds mapped geometry

### DIFF
--- a/freecad/Curves/Sketch_On_Surface.py
+++ b/freecad/Curves/Sketch_On_Surface.py
@@ -198,6 +198,11 @@ class sketchOnSurface:
         for i, wirelist in enumerate(bs.sort()):
             # print(wirelist)
             f = validated_face(wirelist[0], face.Surface) #should valid or null...
+            if f.isNull():
+                # validated_face() gave up; skip rather than crashing in
+                # isValid() below with Standard_NullObject on a NULL shape.
+                error("{:3}:Could not build face from projected wire; skipping\n".format(i))
+                continue
             try:
                 f.check()
             except Exception as e:
@@ -298,6 +303,21 @@ class sketchOnSurface:
         comp = Part.Compound(skedges)
 
         bb = comp.BoundBox
+        # Include ExtraObjects so the mapping domain always contains every
+        # shape being mapped. This prevents two failure modes:
+        #   * glyphs that overshoot the sketch bounds mapping outside the
+        #     target face's parameter range (fails Part.Face validation)
+        #   * an empty sketch producing a degenerate ±MAX_DOUBLE bbox, which
+        #     builds a NaN quad surface and hangs BRepAlgo_NormalProjection
+        #     in a non-converging Newton iteration.
+        for eo in obj.ExtraObjects:
+            if eo is not None and not eo.Shape.isNull():
+                bb.add(eo.Shape.BoundBox)
+        if not bb.isValid():
+            error("Sketch_On_Surface: no geometry to define mapping bounds. "
+                  "Add a construction rectangle to the sketch, or ensure "
+                  "ExtraObjects contains non-empty shapes.\n")
+            return
         u0, u1, v0, v1 = (bb.XMin, bb.XMax, bb.YMin, bb.YMax)
         debug("Sketch bounds = {}".format((u0, u1, v0, v1)))
         try:


### PR DESCRIPTION
## Summary

Fixes two failure modes in `Sketch_On_Surface.execute()` that both stem from using only the host sketch's bounding box as the mapping domain:

- **Crash** (`Standard_NullObject BRepCheck_Analyzer::Init() - NULL shape`) when geometry in `ExtraObjects` extends past the sketch's construction bounds. Pcurves from the overshoot land outside the target face's parameter range, `Part.Face(surf, wire)` can't validate, `validated_face()` returns a null face, and `build_faces()` crashes calling `isValid()` on that null shape.
- **UI hang** when all sketch geometry is deleted. `Part.Compound([]).BoundBox` is the "invalid" bbox `(±MAX_DOUBLE, ...)`. `stretched_plane()` then produces a BSpline "quad" with NaN/inf control points, and `BRepAlgo_NormalProjection::Build` (called via `quad.project([edge])`) gets stuck in a non-converging Newton iteration inside `Extrema_GenExtPS::FindSolution`. Because recompute runs on the main GUI thread, the whole FreeCAD window freezes. (Confirmed via a macOS Spindump stack sample.)

## Fix

- Union `ExtraObjects` bboxes into the mapping domain so the domain always covers everything being mapped.
- Guard against `bb.isValid() == False` with a user-facing error rather than feeding ±MAX_DOUBLE into the quad.
- In `build_faces()`, skip null faces returned by `validated_face()` instead of calling `isValid()` on them (the sibling helper `BoundarySorter.fine_check_inside` already follows this pattern).

Diff is +20 lines, no deletions. No API changes.

## Reproduction case

`Draft.ShapeString` → linked in `ExtraObjects`, mapped sketch has a 120×10 construction rectangle, but glyphs span Y = -2.83..11.03. Toggling `FillFaces = True` crashes; deleting the construction rectangle hangs the UI. With this patch the first case produces all faces cleanly; the second case shows the error message instead of hanging.

## Test plan

- [ ] Build/install the addon
- [ ] Open a document with `Sketch_On_Surface` where `ExtraObjects` overshoots the sketch construction rectangle → toggle `FillFaces`, verify faces render and no `Standard_NullObject` exception
- [ ] Delete all geometry from the sketch → verify FreeCAD shows the error and does not hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)